### PR TITLE
Override the sudo/become for 'Get local path'

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -6,6 +6,7 @@
 # Handles the deployment based on the strategy specified.
 ---
 - name: Get local path.
+  become: false
   local_action: shell pwd
   register: local_path
   ignore_errors: true


### PR DESCRIPTION
We use sudo/become feature when deploying to have the tasks run. This fails in the get local path task. This fixes it for our use case. I don't expect it would cause issues for others either.