### PR TITLE
Add abitlity to symlink multiple configurable files or directories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ symfony_composer_options: --no-dev --no-interaction --optimize-autoloader
 symfony_asset_options: ''
 symfony_releases: 5
 symfony_local_root: /
+symfony_symlinks: [ ]

--- a/tasks/symlinks.yml
+++ b/tasks/symlinks.yml
@@ -51,3 +51,15 @@
   when: uploads_path_deleted|success
   register: symlinks_created
   ignore_errors: true
+
+- name: Delete additional symlinks
+  shell: rm -fr {{ symfony_root_dir }}/releases/{{ release_version.stdout }}/{{ item }}
+  ignore_errors: true
+  with_items: symfony_symlinks
+
+- name: Create additional symlinks
+  file: state=link src={{ symfony_root_dir }}/shared/{{item}} path={{ symfony_root_dir }}/releases/{{ release_version.stdout }}/{{item}}
+  register: additional_symlinks_created
+  ignore_errors: true
+  with_items: symfony_symlinks
+


### PR DESCRIPTION
We sometimes have other files or directories that when deployed should be symlinked. This allows us to do so. I've tested it on one project and it seems to work well.