### PR TITLE
don't fetch the full git repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ symfony_asset_options: ''
 symfony_releases: 5
 symfony_local_root: /
 symfony_symlinks: [ ]
+symfony_git_depth: 10
+

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -18,7 +18,7 @@
   register: deployed
 
 - name: Git deploy.
-  git: repo={{ symfony_repo }} dest={{ symfony_root_dir }}/releases/{{ release_version.stdout }} version={{ symfony_branch }}
+  git: repo={{ symfony_repo }} dest={{ symfony_root_dir }}/releases/{{ release_version.stdout }} version={{ symfony_branch }} depth={{ symfony_git_depth }}
   when: symfony_strategy == "git" and local_path|success
   ignore_errors: true
   register: deployed


### PR DESCRIPTION
There's no reason when deploying to a production machine we should have X full copies of the git repository, setting the depth option should speed up deployment, and reduce the storage requirements.