### PR TITLE
Allow dump_assets to be optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ symfony_asset_options: ''
 symfony_releases: 5
 symfony_local_root: /
 symfony_symlinks: [ ]
+symfony_dump_assets: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
 
 - name: Dump assets.
   shell: cd {{ symfony_root_dir }}/releases/{{ release_version.stdout }} && {{ symfony_php_path }} app/console assetic:dump --env={{ symfony_env }} {{ symfony_asset_options }}
+  when: symfony_dump_assets == true
   register: dump_assets
   ignore_errors: true
 


### PR DESCRIPTION
Sometimes assetic requires nodejs to run some of its tools. However
some projects may not use it and calling assets:dump causes issues.
This makes it optional. Also symfony 3 removed assetic from the default
distribution.